### PR TITLE
Consult API after subscription

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,20 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/app/src/main/java/br/org/cesar/madmovies/movies/view/MoviesActivity.kt
+++ b/app/src/main/java/br/org/cesar/madmovies/movies/view/MoviesActivity.kt
@@ -7,6 +7,8 @@ import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -23,10 +25,8 @@ class MoviesActivity : ComponentActivity() {
     lateinit var navController: NavHostController
     private val viewModel by viewModels<ListMoviesViewModel>()
 
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         setContent {
            MovieActivity()
         }
@@ -34,12 +34,14 @@ class MoviesActivity : ComponentActivity() {
 
     @Composable
     private fun MovieActivity() {
+        val state = viewModel.movieListFlow.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .collectAsState(initial = listOf())
         MADMoviesTheme {
             navController = rememberNavController()
             NavHost(navController = navController,
                 startDestination = "movieList") {
                 composable("movieList") {
-                    MovieList(viewModel.movieListFlow.collectAsState(), navController)
+                    MovieList(state, navController)
                 }
                 composable(
                     "movieDetails/{movie}",

--- a/app/src/main/java/br/org/cesar/madmovies/movies/viewmodel/ListMoviesViewModel.kt
+++ b/app/src/main/java/br/org/cesar/madmovies/movies/viewmodel/ListMoviesViewModel.kt
@@ -5,8 +5,7 @@ import androidx.lifecycle.viewModelScope
 import br.org.cesar.madmovies.movies.data.remote.RemoteRepository
 import br.org.cesar.madmovies.movies.domain.model.Movie
 import br.org.cesar.madmovies.movies.domain.usecase.GetMovieList
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
 class ListMoviesViewModel : ViewModel() {
@@ -14,10 +13,8 @@ class ListMoviesViewModel : ViewModel() {
     private var _movieListFlow: MutableStateFlow<List<Movie>> = MutableStateFlow(mutableListOf())
     var movieListFlow: StateFlow<List<Movie>> =
         _movieListFlow
-
-    init {
-        updateMovieList()
-    }
+            .onSubscription { updateMovieList() }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(2000), _movieListFlow.value)
 
     fun updateMovieList() {
         viewModelScope.launch {


### PR DESCRIPTION
After this change, the use case will be called after the first subscription, and the value will be cached
and emitted for every other subscription.

The cached value will be erased if there are no subscriptions after 2 seconds, so the cache is not
erased on configuration changes. If a subscription happens after the cache is erased a new call
will be made to the use case

Fixes #1 